### PR TITLE
Create annotated git tags.

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -26,7 +26,7 @@ export default class GitUtilities {
 
   @logger.logifySync()
   static addTag(tag) {
-    ChildProcessUtilities.execSync("git tag " + tag);
+    ChildProcessUtilities.execSync("git tag -a " + tag + " -m \"" + tag + "\"");
   }
 
   @logger.logifySync()


### PR DESCRIPTION
Lerna uses its git tags to determine which packages have been
updated since the last publication, so it's important that tags be
committed to the repository. Git's annotated tags are designed
for this in a way that lightweight tags are not. For example, only
annotated tags are pushed by `git push --follow-tags`.